### PR TITLE
Don't redeclare corner[Min]Width/Height

### DIFF
--- a/extend-left-box@linuxdeepin.com/extension.js
+++ b/extend-left-box@linuxdeepin.com/extension.js
@@ -58,8 +58,8 @@ function allocate(actor, box, flags) {
     childBox.y2 = allocHeight + cornerHeight;
     panel._leftCorner.actor.allocate(childBox, flags);
 
-    let [cornerMinWidth, cornerWidth] = panel._rightCorner.actor.get_preferred_width(-1);
-    let [cornerMinHeight, cornerHeight] = panel._rightCorner.actor.get_preferred_width(-1);
+    [cornerMinWidth, cornerWidth] = panel._rightCorner.actor.get_preferred_width(-1);
+    [cornerMinHeight, cornerHeight] = panel._rightCorner.actor.get_preferred_width(-1);
     childBox.x1 = allocWidth - cornerWidth;
     childBox.x2 = allocWidth;
     childBox.y1 = allocHeight;

--- a/extend-left-box@linuxdeepin.com/metadata.json
+++ b/extend-left-box@linuxdeepin.com/metadata.json
@@ -2,6 +2,6 @@
     "uuid": "extend-left-box@linuxdeepin.com",
     "name": "Extend left box",
     "description": "Extend _leftBox of gnome-shell top panel",
-    "shell-version": [ "3.4", "3.6", "3.8" , "3.10", "3.12" ],
+    "shell-version": [ "3.4", "3.6", "3.8" , "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.22", "3.24" ],
     "url": "http://github.com/StephenPCG/extend-left-box"
 }


### PR DESCRIPTION
Don't redeclare corner[Min]Width/Height.  Makes gnome-shell 3.24 happy and load the extension again.

